### PR TITLE
added default parameters

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -33,10 +33,13 @@ class ViewController: UIViewController {
 
     // MARK: Alert
     @IBAction func showDefaultAlert(sender: UIButton) {
+//        UIAlertController.present(title: "title") { (action) -> () in
+//        UIAlertController.present(message: "message") { (action) -> () in
         UIAlertController.present(title: "title", message: "message", actionTitles: ["OK", "Cancel", "Destroy"]) { (action) -> () in
             print(action.title)
         }
     }
+    
     
     @IBAction func showAttributedAlert(sender: UIButton) {
         UIAlertController.present(title: "title", message: "message", attributedActionTitles: [("OK", .Default), ("Cancel", .Cancel), ("Destroy", .Destructive)]) { (action) -> () in

--- a/Source/UIAlertControllerExtension.swift
+++ b/Source/UIAlertControllerExtension.swift
@@ -29,14 +29,14 @@ public typealias AttributedActionTitle = (title: String, style: UIAlertActionSty
 public extension UIAlertController {
     
     // Support Present UIAlertController from anywhere. It will be presented by Top Presented ViewController.
-    public class func present(style: UIAlertControllerStyle = .Alert, title: String?, message: String?, actionTitles: [String]?, handler: ActionHandler? = nil) -> UIAlertController {
+    public class func present(style: UIAlertControllerStyle = .Alert, title: String? = nil, message: String? = nil, actionTitles: [String]? = ["OK"], handler: ActionHandler? = nil) -> UIAlertController {
         // Force unwrap rootViewController
         let rootViewController = UIApplication.sharedApplication().delegate!.window!!.rootViewController!
         
         return self.presentFromViewController(rootViewController, style: style, title: title, message: message, actionTitles: actionTitles, handler: handler)
     }
     
-    public class func present(style: UIAlertControllerStyle = .Alert, title: String?, message: String?, attributedActionTitles: [AttributedActionTitle]?, handler: ActionHandler? = nil) -> UIAlertController {
+    public class func present(style: UIAlertControllerStyle = .Alert, title: String? = nil, message: String? = nil, attributedActionTitles: [AttributedActionTitle]?, handler: ActionHandler? = nil) -> UIAlertController {
         // Force unwrap rootViewController
         let rootViewController = UIApplication.sharedApplication().delegate!.window!!.rootViewController!
         
@@ -72,11 +72,11 @@ public extension UIAlertController {
 
 // MARK:
 public extension UIViewController {
-    public func presentAlert(style: UIAlertControllerStyle = .Alert, title: String?, message: String?, actionTitles: [String]?, handler: ActionHandler? = nil) -> UIAlertController {
+    public func presentAlert(style: UIAlertControllerStyle = .Alert, title: String? = nil, message: String? = nil, actionTitles: [String]? = ["OK"], handler: ActionHandler? = nil) -> UIAlertController {
         return UIAlertController.presentFromViewController(self, style: style, title: title, message: message, actionTitles: actionTitles, handler: handler)
     }
     
-    public func presentAlert(style: UIAlertControllerStyle = .Alert, title: String?, message: String?, attributedActionTitles: [AttributedActionTitle]?, handler: ActionHandler? = nil) -> UIAlertController {
+    public func presentAlert(style: UIAlertControllerStyle = .Alert, title: String? = nil, message: String? = nil, attributedActionTitles: [AttributedActionTitle]?, handler: ActionHandler? = nil) -> UIAlertController {
         return UIAlertController.presentFromViewController(self, style: style, title: title, message: message, attributedActionTitles: attributedActionTitles, handler: handler)
     }
     


### PR DESCRIPTION
adding default parameters for `titles:` and `message:` are useful for title/message-only alert.
and default with `actionTitles: [String]? = ["OK"]` useful for OK button only alert.

then message-only alert will be this simple!

``` swift
UIAlertController.present(message: "message") { (action) -> () in
  // do something
}     
```
